### PR TITLE
Feat: load callback plugins for print task execution time

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -6,6 +6,8 @@ on:  # yamllint disable-line rule:truthy
     tags_ignore:
       - '*'
   pull_request:
+  schedule:
+    - cron: '0 0 1 */3 *'
 
 jobs:
   setup:
@@ -39,11 +41,10 @@ jobs:
         with:
           path: "${{ github.repository }}"
       - name: molecule
-        uses: robertdebock/molecule-action@4.0.9
+        uses: ansible/ansible-lint-action@main
         with:
-          command: lint
-          scenario: ${{ fromJson(needs.setup.outputs.scenarios)[0] }}
-
+          path: "."
+  
   test:
     name: Scenario "${{ matrix.scenario }}" on ${{ matrix.config.image }}:${{ matrix.config.tag }}
     needs:
@@ -60,21 +61,24 @@ jobs:
             tag: "latest"
           - image: "debian"
             tag: "11"
+          - image: "debian"
+            tag: "12"
           - image: "ubuntu"
             tag: "20.04"
           - image: "ubuntu"
             tag: "22.04"
-
     steps:
       - name: checkout
         uses: actions/checkout@v3
         with:
           path: "${{ github.repository }}"
       - name: molecule
-        uses: robertdebock/molecule-action@4.0.9
+        uses: gofrolist/molecule-action@v2
         with:
+          # molecule_options: --debug
+          molecule_command: test
+          molecule_args: --scenario-name ${{ matrix.scenario }} -d docker
+          molecule_working_dir: "${{ github.repository }}"
+        env:
           image: ${{ matrix.config.image }}
           tag: ${{ matrix.config.tag }}
-          scenario: ${{ matrix.scenario }}
-        env:
-          name: ${{ matrix.config.name }}

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,6 +1,9 @@
 ---
 dependency:
-  name: galaxy
+  name: shell
+  command: |
+    pip install requests pytest-testinfra &&
+    ansible-galaxy collection install community.crypto community.general
 
 driver:
   name: docker
@@ -26,6 +29,9 @@ provisioner:
   name: ansible
   env:
     ANSIBLE_FORCE_COLOR: "true"
+    ANSIBLE_LOAD_CALLBACK_PLUGINS: "true"
+    ANSIBLE_CALLBACKS_ENABLED: "ansible.posix.profile_tasks"
+    ANSIBLE_STDOUT_CALLBACK: "ansible.posix.debug"
   options:
     v: true
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Show molecule scenario execution time by loading some ansible callback plugins

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For be able to get role average execution time 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
No specific tests for that.

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] feat: add schedule for run workflow each three months
- [x] tests: add debian 12 support
- [x] feat: load pluging for display scenario execution time 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires no change to the documentation.
